### PR TITLE
feat/FAVORY-10-인풋-컴포넌트

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -4,7 +4,7 @@ import {
   LabelHTMLAttributes,
   PropsWithChildren,
 } from "react";
-import { cva } from "class-variance-authority";
+import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/cn";
 
 export function Label({
@@ -39,12 +39,6 @@ export function Error({ children }: { children: ReactNode }) {
   );
 }
 
-export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
-  label?: string;
-  error?: string;
-  inputRef?: Ref<HTMLInputElement>;
-};
-
 const inputVariants = cva(
   "mt-2 h-[32px] w-full rounded-md border bg-white p-3 text-sm text-black placeholder:text-black-200 focus:outline-none transition-colors duration-150 md:h-[38px] lg:h-[40px] lg:text-md disabled:opacity-50 disabled:bg-black-200/7 disabled:cursor-not-allowed",
   {
@@ -62,6 +56,14 @@ const inputVariants = cva(
   },
 );
 
+export interface InputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {
+  label?: string;
+  error?: string;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
 export default function Input({
   label,
   error,
@@ -69,6 +71,7 @@ export default function Input({
   inputRef,
   required,
   disabled,
+  state,
   ...props
 }: InputProps) {
   const id = useId();
@@ -83,13 +86,12 @@ export default function Input({
       <input
         id={id}
         ref={inputRef}
-        className={inputVariants({
-          state: error ? "error" : "default",
-          className,
-        })}
-        aria-invalid={!!error}
-        required={required}
         disabled={disabled}
+        required={required}
+        aria-invalid={!!error}
+        className={cn(
+          inputVariants({ state: error ? "error" : state, className }),
+        )}
         {...props}
       />
       {error && <Error>{error}</Error>}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,98 @@
+import { ReactNode, Ref, useId } from "react";
+import {
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+  PropsWithChildren,
+} from "react";
+import { cva } from "class-variance-authority";
+import { cn } from "@/lib/cn";
+
+export function Label({
+  required,
+  children,
+  className,
+  ...props
+}: PropsWithChildren<
+  LabelHTMLAttributes<HTMLLabelElement> & { required?: boolean }
+>) {
+  return (
+    <label
+      className={cn(
+        "text-md flex items-center gap-1 font-medium text-black lg:text-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {required && (
+        <span className="text-error-100 text-lg font-medium">*</span>
+      )}
+    </label>
+  );
+}
+
+export function Error({ children }: { children: ReactNode }) {
+  return (
+    <span className="text-error-100 lg:text-md mt-2 block text-sm">
+      {children}
+    </span>
+  );
+}
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  label?: string;
+  error?: string;
+  inputRef?: Ref<HTMLInputElement>;
+};
+
+const inputVariants = cva(
+  "mt-2 h-[32px] w-full rounded-md border bg-white p-3 text-sm text-black placeholder:text-black-200 focus:outline-none transition-colors duration-150 md:h-[38px] lg:h-[40px] lg:text-md disabled:opacity-50 disabled:bg-black-200/7 disabled:cursor-not-allowed",
+  {
+    variants: {
+      state: {
+        default:
+          "border-black-200 hover:bg-black-200/7 focus:border-green-500 focus:bg-green-500/7 focus:shadow-[0_0_0_3px_rgba(7,102,83,0.4)]",
+        error:
+          "border-error-100 hover:bg-black-200/7 focus:border-error-500 focus:bg-error-100/7 focus:shadow-[0_0_0_3px_rgba(239,68,68,0.4)]",
+      },
+    },
+    defaultVariants: {
+      state: "default",
+    },
+  },
+);
+
+export default function Input({
+  label,
+  error,
+  className,
+  inputRef,
+  required,
+  disabled,
+  ...props
+}: InputProps) {
+  const id = useId();
+
+  return (
+    <div>
+      {label && (
+        <Label required={required} htmlFor={id}>
+          {label}
+        </Label>
+      )}
+      <input
+        id={id}
+        ref={inputRef}
+        className={inputVariants({
+          state: error ? "error" : "default",
+          className,
+        })}
+        aria-invalid={!!error}
+        required={required}
+        disabled={disabled}
+        {...props}
+      />
+      {error && <Error>{error}</Error>}
+    </div>
+  );
+}


### PR DESCRIPTION
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 공통 컴포넌트 Input 컴포넌트 작업 내용입니다.
- cva, cn 함수를 사용해 중복 클래스 병합 처리 개선
- useId 사용해 label과 input 연결
- Button 컴포넌트와 동일한 구조로 cva, VariantProps + cn 패턴 적용
- props
  - label?: 인풋 상단에 표시할 라벨 텍스트
  - error?: 에러 메시지 텍스트
  - inputRef?: 외부에서 input ref 접근 가능
  - required?: 필수 입력 여부
  - disabled?: 비활성화 상태 여부(hover/focus 스타일 제거, opacity 처리)
<img width="1260" height="290" alt="스크린샷(229)" src="https://github.com/user-attachments/assets/6f63bfb9-36f6-4c28-880b-9c8f133a870e" />
<img width="1241" height="382" alt="스크린샷(230)" src="https://github.com/user-attachments/assets/3fd7dab1-5407-4227-9f06-bb72090dd002" />

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee, Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
